### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/viralshah0039/fbc02992-716b-49f5-bfa0-2ef9e50bab80/ef2fb831-a31e-4d37-a5c4-6aeaaeb9fad3/_apis/work/boardbadge/75d33fa3-bb06-4535-bc71-beef32163b56)](https://dev.azure.com/viralshah0039/fbc02992-716b-49f5-bfa0-2ef9e50bab80/_boards/board/t/ef2fb831-a31e-4d37-a5c4-6aeaaeb9fad3/Microsoft.RequirementCategory)
 ![img.png](lynx.png)
 
 ## What is DeepLynx?


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/viralshah0039/fbc02992-716b-49f5-bfa0-2ef9e50bab80/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.